### PR TITLE
fix: mutation forgotPassword variable data got invalid type string

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -14,7 +14,7 @@ export class Users {
 
   public async forgotPassword(email: string): Promise<void> {
     await this.client.mutate({
-      mutation: FORGOT_PASSWORD_MUTATION, variables: { data: email }
+      mutation: FORGOT_PASSWORD_MUTATION, variables: { data: { email } }
     });
   }
 }


### PR DESCRIPTION
This PR is trying to fix this error:
![image](https://user-images.githubusercontent.com/47613233/229180210-7aaf48c6-cae3-463f-a530-323e607302b1.png)

The `FORGOT_PASSWORD_MUTATION` is expecting a variable of type `{ data: { email: string } }` but currently is receiving a type `{ data: string }`

To reproduce the error use the method `forgotPassword` in the current version (`0.0.5`)