### PR TITLE
feat: locations module integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache, RequestHandler, NormalizedCacheObject } from "@apollo/client/core";
-import { App, Auth, Users, CustomFields } from './modules';
+import { App, Auth, Users, CustomFields, Locations } from './modules';
 import { setContext } from '@apollo/client/link/context';
 import Settings from "./modules/settings";
 
@@ -38,6 +38,7 @@ export default class KanvasCore {
   public customFields: CustomFields;
   public app: App;
   public settings: Settings;
+  public locations: Locations;
 
   constructor(protected options: Options) {
     this.client = new ApolloClient({
@@ -50,6 +51,7 @@ export default class KanvasCore {
     this.users = new Users(this.client);
     this.customFields = new CustomFields(this.client);
     this.settings = new Settings(this.client, this.options.key);
+    this.locations = new Locations(this.client)
   }
 
   protected generateURL() {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -2,3 +2,4 @@ export * from './app';
 export * from './auth';
 export * from './users';
 export * from './custom-fields';
+export * from './locations';

--- a/src/modules/locations/index.ts
+++ b/src/modules/locations/index.ts
@@ -1,18 +1,18 @@
-import { countriesResponse, stateResponse } from 'types/locations';
+import { StateResponse, CountriesResponse } from 'types/locations';
 import { ClientType } from '../../index';
 import { COUNTRIES_QUERY, GET_STATES_BY_COUNTRY_QUERY } from '../../queries';
 
 export class Locations {
   constructor(protected client: ClientType) {}
 
-  public async getAllCountries() {
+  public async getAllCountries(): Promise<CountriesResponse> {
     const response = await this.client.query({
       query: COUNTRIES_QUERY,
     });
-    return response.data.countries as countriesResponse;
+    return response.data as CountriesResponse;
   }
 
-  public async getStatesByCountry(id: number) {
+  public async getStatesByCountry(id: number): Promise<StateResponse> {
     const response = await this.client.query({
       query: GET_STATES_BY_COUNTRY_QUERY,
       variables: {
@@ -24,6 +24,6 @@ export class Locations {
         },
       },
     });
-    return response.data.countries as stateResponse;
+    return response.data.countries as StateResponse;
   }
 }

--- a/src/modules/locations/index.ts
+++ b/src/modules/locations/index.ts
@@ -1,3 +1,4 @@
+import { countriesResponse, stateResponse } from 'types/locations';
 import { ClientType } from '../../index';
 import { COUNTRIES_QUERY, GET_STATES_BY_COUNTRY_QUERY } from '../../queries';
 
@@ -8,7 +9,7 @@ export class Locations {
     const response = await this.client.query({
       query: COUNTRIES_QUERY,
     });
-    return response.data.countries;
+    return response.data.countries as countriesResponse;
   }
 
   public async getStatesByCountry(id: number) {
@@ -23,6 +24,6 @@ export class Locations {
         },
       },
     });
-    return response.data.countries.data;
+    return response.data.countries as stateResponse;
   }
 }

--- a/src/modules/locations/index.ts
+++ b/src/modules/locations/index.ts
@@ -9,7 +9,7 @@ export class Locations {
     const response = await this.client.query({
       query: COUNTRIES_QUERY,
     });
-    return response.data as CountriesResponse;
+    return response.data;
   }
 
   public async getStatesByCountry(id: number): Promise<StateResponse> {
@@ -24,6 +24,6 @@ export class Locations {
         },
       },
     });
-    return response.data.countries as StateResponse;
+    return response.data.countries;
   }
 }

--- a/src/modules/locations/index.ts
+++ b/src/modules/locations/index.ts
@@ -1,0 +1,28 @@
+import { ClientType } from '../../index';
+import { COUNTRIES_QUERY, GET_STATES_BY_COUNTRY_QUERY } from '../../queries';
+
+export class Locations {
+  constructor(protected client: ClientType) {}
+
+  public async getAllCountries() {
+    const response = await this.client.query({
+      query: COUNTRIES_QUERY,
+    });
+    return response.data.countries;
+  }
+
+  public async getStatesByCountry(id: number) {
+    const response = await this.client.query({
+      query: GET_STATES_BY_COUNTRY_QUERY,
+      variables: {
+        first: 100,
+        where: {
+          column: 'ID',
+          operator: 'EQ',
+          value: id,
+        },
+      },
+    });
+    return response.data.countries.data;
+  }
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,2 +1,3 @@
 export * from './app.query';
 export * from './settings.query';
+export * from './locations.query';

--- a/src/queries/locations.query.ts
+++ b/src/queries/locations.query.ts
@@ -1,0 +1,38 @@
+import { gql } from '@apollo/client/core';
+
+export const COUNTRIES_QUERY = gql`
+  query {
+    countries(first: 250, orderBy: [{ column: ID, order: ASC }]) {
+      data {
+        id
+        name
+      }
+      paginatorInfo {
+        currentPage
+        lastPage
+      }
+    }
+  }
+`;
+
+export const GET_STATES_BY_COUNTRY_QUERY = gql`
+  query GetStatesByCountry(
+    $first: Int!
+    $where: QueryCountriesWhereWhereConditions
+  ) {
+    countries(first: $first, where: $where) {
+      data {
+        id
+        states {
+          id
+          name
+          code
+          cities {
+            name
+            latitude
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/queries/locations.query.ts
+++ b/src/queries/locations.query.ts
@@ -6,6 +6,7 @@ export const COUNTRIES_QUERY = gql`
       data {
         id
         name
+        code
       }
       paginatorInfo {
         currentPage
@@ -29,7 +30,7 @@ export const GET_STATES_BY_COUNTRY_QUERY = gql`
           code
           cities {
             name
-            latitude
+            countries_id
           }
         }
       }

--- a/src/types/locations.ts
+++ b/src/types/locations.ts
@@ -1,6 +1,7 @@
 interface Location {
   id: number;
   name: string;
+  code: string;
 }
 
 interface Country extends Location {
@@ -11,14 +12,15 @@ interface State extends Location {
   cities: Array<City>;
 }
 
-interface City extends Location {
+interface City extends Omit<Location, 'code'> {
   country_id: number;
 }
 
-export interface countriesResponse {
+export interface CountriesResponse {
   data: Array<Country>;
+  paginatorInfo: Record<string, number>;
 }
 
-export interface stateResponse {
+export interface StateResponse {
   data: Array<State>;
 }

--- a/src/types/locations.ts
+++ b/src/types/locations.ts
@@ -1,0 +1,24 @@
+interface Location {
+  id: number;
+  name: string;
+}
+
+interface Country extends Location {
+  states: Array<State>;
+}
+
+interface State extends Location {
+  cities: Array<City>;
+}
+
+interface City extends Location {
+  country_id: number;
+}
+
+export interface countriesResponse {
+  data: Array<Country>;
+}
+
+export interface stateResponse {
+  data: Array<State>;
+}


### PR DESCRIPTION
### **Description**
This pull request adds a new feature that integrates the locations module from Kanvas GraphQL API. With this new feature, users will be able to access to countries, cities and states/provincies

### **Changes Made**

- Added a new Locations class to the codebase.
- Added some gql queries to retrieve the locations.
- Implemented the getAllCountries method to retrieve a list of all countries from Kanvas API.
- Implemented the getStatesByCountry method to retrieve a list of states/provinces for a given country ID from Kanvas API.