### PR TITLE
hotfix: message search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.4",
+  "version": "0.7.5",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.5",
+  "version": "0.8.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/modules/messages/index.ts
+++ b/src/modules/messages/index.ts
@@ -132,17 +132,6 @@ export class Messages {
     return response.data.messages as MessagesInterface[];
   }
 
-  public async searchMessages(search: string): Promise<MessagesInterface[]> {
-    const response = await this.client.query({
-      query: GET_MESSAGES_QUERY,
-      variables: {
-        search,
-      },
-      fetchPolicy: 'no-cache',
-    });
-    return response.data.messages as MessagesInterface[];
-  }
-
   public async getMessagesGroupByDate(
     where: WhereCondition,
     hasAppModuleMessageWhere: HasAppModuleMessageWhereConditions,

--- a/src/modules/messages/index.ts
+++ b/src/modules/messages/index.ts
@@ -7,7 +7,7 @@ import {
   HasAppModuleMessageWhereConditions,
   OrderByMessage,
   WhereCondition,
-  MessageUpdateInputInterface
+  MessageUpdateInputInterface,
 } from '../../types';
 import {
   CREATE_MESSAGE_MUTATION,
@@ -24,7 +24,11 @@ import {
   DISLIKE_MESSAGE_MUTATION,
 } from '../../mutations';
 
-import { GET_MESSAGES_BY_DISPLAYNAME_AND_SLUG, GET_MESSAGES_GROUP_BY_DATE_QUERY, GET_MESSAGES_QUERY } from '../../queries';
+import {
+  GET_MESSAGES_BY_DISPLAYNAME_AND_SLUG,
+  GET_MESSAGES_GROUP_BY_DATE_QUERY,
+  GET_MESSAGES_QUERY,
+} from '../../queries';
 import { MessagesComments } from '../messages-comments';
 export class Messages {
   public comments: MessagesComments;
@@ -90,15 +94,27 @@ export class Messages {
   }
 
   public async getMessages(
-    where: WhereCondition,
-    hasAppModuleMessageWhere: HasAppModuleMessageWhereConditions,
-    orderBy: Array<OrderByMessage>,
-    search: string,
-    first: number,
-    page: number,
-    hasTags?: WhereCondition,
-    hasType?: WhereCondition
+    options: {
+      where?: WhereCondition;
+      hasAppModuleMessageWhere?: HasAppModuleMessageWhereConditions;
+      orderBy?: Array<OrderByMessage>;
+      search?: string;
+      first?: number;
+      page?: number;
+      hasTags?: WhereCondition;
+      hasType?: WhereCondition;
+    } = {}
   ): Promise<MessagesInterface[]> {
+    const {
+      hasAppModuleMessageWhere,
+      search,
+      hasTags,
+      hasType,
+      where,
+      orderBy,
+      first,
+      page,
+    } = options;
     const response = await this.client.query({
       query: GET_MESSAGES_QUERY,
       variables: {
@@ -116,13 +132,11 @@ export class Messages {
     return response.data.messages as MessagesInterface[];
   }
 
-  public async searchMessages(
-    search: string
-  ): Promise<MessagesInterface[]> {
+  public async searchMessages(search: string): Promise<MessagesInterface[]> {
     const response = await this.client.query({
       query: GET_MESSAGES_QUERY,
       variables: {
-        search
+        search,
       },
       fetchPolicy: 'no-cache',
     });
@@ -162,7 +176,6 @@ export class Messages {
     });
     return response.data.messages as MessagesInterface;
   }
-
 
   public async attachTopicToMessage(
     messageId: string,

--- a/src/modules/messages/index.ts
+++ b/src/modules/messages/index.ts
@@ -116,6 +116,19 @@ export class Messages {
     return response.data.messages as MessagesInterface[];
   }
 
+  public async searchMessages(
+    search: string
+  ): Promise<MessagesInterface[]> {
+    const response = await this.client.query({
+      query: GET_MESSAGES_QUERY,
+      variables: {
+        search
+      },
+      fetchPolicy: 'no-cache',
+    });
+    return response.data.messages as MessagesInterface[];
+  }
+
   public async getMessagesGroupByDate(
     where: WhereCondition,
     hasAppModuleMessageWhere: HasAppModuleMessageWhereConditions,

--- a/test/message.test.ts
+++ b/test/message.test.ts
@@ -23,13 +23,11 @@ describe('Test the Social Messages', () => {
     it('get messages', async () => {
         const client = getClient();
         const messages = client.messages;
-        const recentMessages = await messages.getMessages(
-            {} as WhereCondition,
-            {} as HasAppModuleMessageWhereConditions,
-            [{ column: 'CREATED_AT', order: 'DESC' }],
-            '',
-            25,
-            1
+        const recentMessages = await messages.getMessages({
+            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            first: 25,
+            page: 1
+        }
         );
         expect(recentMessages).toBeDefined();
     });
@@ -48,8 +46,8 @@ describe('Test the Social Messages', () => {
         expect(newMessage.id).toBeDefined();
         expect(newMessage.message).toBe(messageContent);
 
-        const recentMessages = await messages.getMessages(
-            {
+        const recentMessages = await messages.getMessages({
+            where: {
                 column: 'MESSAGE_TYPES_ID',
                 operator: 'EQ',
                 value: 'post2',
@@ -60,13 +58,11 @@ describe('Test the Social Messages', () => {
                         value: newMessage.user.id,
                     }
                 ],
-            } as WhereCondition,
-            {} as HasAppModuleMessageWhereConditions,
-            [{ column: 'CREATED_AT', order: 'DESC' }],
-            '',
-            25,
-            1
-        );
+            },
+            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            first: 25,
+            page: 1
+        });
         expect(recentMessages).toBeDefined();
     });
 
@@ -84,21 +80,18 @@ describe('Test the Social Messages', () => {
         expect(newMessage.id).toBeDefined();
         expect(newMessage.message).toBe(messageContent);
 
-        const recentMessages = await messages.getMessages(
-            {
+        const recentMessages = await messages.getMessages({
+            where: {
                 column: 'USERS_ID',
                 operator: 'EQ',
                 value: newMessage.user.id,
 
             } as WhereCondition,
-            {} as HasAppModuleMessageWhereConditions,
-            [{ column: 'CREATED_AT', order: 'DESC' }],
-            '',
-            25,
-            1,
-            {} as WhereCondition,
-            { column: 'VERB', operator: 'EQ', value: 'post2' } as WhereCondition
-        );
+            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            first: 25,
+            page: 1,
+            hasType: { column: 'VERB', operator: 'EQ', value: 'post2' } as WhereCondition
+        });
         expect(recentMessages).toBeDefined();
     });
 
@@ -116,15 +109,12 @@ describe('Test the Social Messages', () => {
         expect(newMessage.id).toBeDefined();
         expect(newMessage.message).toBe(messageContent);
 
-        const recentMessages = await messages.getMessages(
-            {} as WhereCondition,
-            {} as HasAppModuleMessageWhereConditions,
-            [{ column: 'CREATED_AT', order: 'DESC' }],
-            '',
-            25,
-            1,
-            { column: 'SLUG', operator: 'EQ', value: 'post2' } as WhereCondition,
-        );
+        const recentMessages = await messages.getMessages({
+            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            first: 25,
+            page: 1,
+            hasTags: { column: 'SLUG', operator: 'EQ', value: 'post2' } as WhereCondition,
+        });
         expect(recentMessages).toBeDefined();
     });
 
@@ -142,9 +132,9 @@ describe('Test the Social Messages', () => {
         expect(newMessage.id).toBeDefined();
         expect(newMessage.message).toBe(messageContent);
 
-        const recentMessages = await messages.searchMessages(
-            'Kanvas'
-        );
+        const recentMessages = await messages.getMessages({ 
+            search: 'Kanvas' 
+        });
         expect(recentMessages).toBeDefined();
     });
 

--- a/test/message.test.ts
+++ b/test/message.test.ts
@@ -88,7 +88,7 @@ describe('Test the Social Messages', () => {
             {
                 column: 'USERS_ID',
                 operator: 'EQ',
-                value: newMessage.user.id, 
+                value: newMessage.user.id,
 
             } as WhereCondition,
             {} as HasAppModuleMessageWhereConditions,
@@ -97,7 +97,7 @@ describe('Test the Social Messages', () => {
             25,
             1,
             {} as WhereCondition,
-            {column: 'VERB', operator: 'EQ', value: 'post2'} as WhereCondition
+            { column: 'VERB', operator: 'EQ', value: 'post2' } as WhereCondition
         );
         expect(recentMessages).toBeDefined();
     });
@@ -123,7 +123,27 @@ describe('Test the Social Messages', () => {
             '',
             25,
             1,
-            {column: 'SLUG', operator: 'EQ', value: 'post2'} as WhereCondition,
+            { column: 'SLUG', operator: 'EQ', value: 'post2' } as WhereCondition,
+        );
+        expect(recentMessages).toBeDefined();
+    });
+
+    it('search by message', async () => {
+        const client = getClient();
+
+        const messages = client.messages;
+        const messageContent = 'Hello, Kanvas!';
+        const newMessage = await messages.createMessage({
+            message_verb: 'post2',
+            message: messageContent,
+        });
+
+        expect(newMessage).toBeDefined();
+        expect(newMessage.id).toBeDefined();
+        expect(newMessage.message).toBe(messageContent);
+
+        const recentMessages = await messages.searchMessages(
+            'Kanvas'
         );
         expect(recentMessages).toBeDefined();
     });


### PR DESCRIPTION
The @search tag in Lighthouse cannot have any other parameters in the query, so we had to create a new method to resolve our issue.