### PR TITLE
Add support for creating orders from Google Play in-app purchases

### DIFF
--- a/src/modules/commerce/orders/index.ts
+++ b/src/modules/commerce/orders/index.ts
@@ -1,6 +1,7 @@
 import { ClientType, GET_ORDERS, OrderBy, WhereCondition } from '../../../index';
 import {
   CREATE_ORDER_FROM_APPLE_IN_APP_PURCHASE,
+  CREATE_ORDER_FROM_GOOGLE_PLAY_IN_APP_PURCHASE,
   CREATE_ORDER_FROM_CART,
   CREATE_ORDER_MUTATION,
   GENERATE_ORDER_PAYMENT_INTENT_MUTATION,
@@ -12,7 +13,9 @@ import {
   OrderCartInput,
   OrderFromCartResults,
   AppleInAppPurchaseReceipt,
+  GooglePlayInAppPurchaseReceipt,
   OrderFromAppleInAppPurchaseResults,
+  OrderFromGooglePlayInAppPurchaseResults,
   CreatedOrders,
 } from '../../../types/commerce';
 
@@ -44,6 +47,17 @@ export class Order {
   ): Promise<OrderFromAppleInAppPurchaseResults> {
     const response = await this.client.mutate({
       mutation: CREATE_ORDER_FROM_APPLE_IN_APP_PURCHASE,
+      variables: { ...input },
+    });
+
+    return response.data;
+  }
+
+  public async createOrderFromGooglePlayInAppPurchaseReceipt(
+    input: GooglePlayInAppPurchaseReceipt
+  ): Promise<OrderFromGooglePlayInAppPurchaseResults> {
+    const response = await this.client.mutate({
+      mutation: CREATE_ORDER_FROM_GOOGLE_PLAY_IN_APP_PURCHASE,
       variables: { ...input },
     });
 

--- a/src/mutations/commerce.mutation.ts
+++ b/src/mutations/commerce.mutation.ts
@@ -67,6 +67,29 @@ export const CREATE_ORDER_FROM_APPLE_IN_APP_PURCHASE = gql`
   }
 `;
 
+export const CREATE_ORDER_FROM_GOOGLE_PLAY_IN_APP_PURCHASE = gql`
+  mutation($input: GooglePlayInAppPurchaseReceipt!) {
+    createOrderFromGooglePlayInAppPurchase(input: $input) {
+        id
+        uuid
+        user_email
+        user_phone
+        order_number
+        status
+        total_gross_amount
+        fulfillment_status
+        items {
+          id
+          product_name
+          product_sku
+          quantity
+          unit_price_gross_amount
+          variant_name
+        }
+      }
+  }
+`;
+
 export const GENERATE_ORDER_PAYMENT_INTENT_MUTATION = gql`
   mutation($amount: Money!) {
     generateOrderPaymentIntent(amount: $amount) {

--- a/src/types/commerce.ts
+++ b/src/types/commerce.ts
@@ -57,6 +57,11 @@ export interface OrderFromAppleInAppPurchaseResults {
   createOrderFromAppleInAppPurchase: Order;
 }
 
+export interface OrderFromGooglePlayInAppPurchaseResults {
+  createOrderFromGooglePlayInAppPurchase: Order;
+}
+
+
 export interface OrderItem {
   id: number;
   product_name: string;
@@ -77,6 +82,16 @@ export interface AppleInAppPurchaseReceipt {
     transaction_id: string;
     receipt: string;
     transaction_date: string;
+    region_id?: number;
+    custom_fields?: CustomFieldInput[];
+  };
+}
+
+export interface GooglePlayInAppPurchaseReceipt {
+  input: {
+    product_id: string;
+    order_id: string;
+    purchase_token: string;
     region_id?: number;
     custom_fields?: CustomFieldInput[];
   };

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -44,4 +44,22 @@ describe('Test Commerce orders', () => {
         expect(result.createOrderFromAppleInAppPurchase.id).toBeDefined();
         expect(result.createOrderFromAppleInAppPurchase.uuid).toBeDefined();
     });
+
+    it('create order from google play in app purchase', async () => {
+        const client = getClient();
+        const order = client.order;
+        await expect(order.createOrderFromGooglePlayInAppPurchaseReceipt({
+            input: {
+                product_id: 'premium_prompt_10',
+                order_id: 'GPA.3339-7776-6046-73659',
+                purchase_token: 'ohbnkhkhlajafkcamjodgjmp.AO-J1OyuQqNGaOjwEx2UH0rMV67gM0H9QH_dkTf3KOZvYvZwXSHWWKBq2H-muArJUIiVKUn42cgEinMwPZZQgLRxiCRbd-9CuQ',
+                custom_fields: [
+                    {
+                        name: 'message_id',
+                        value: '1',
+                    },
+                ],
+            }
+        })).rejects.toThrow("Receipt is in canceled state");
+    });
 });


### PR DESCRIPTION
Introduce functionality to create orders using Google Play in-app purchase receipts, including necessary GraphQL mutations and types. Update tests to validate the new order creation process.