### PR TITLE
fix message file upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.4",
+  "version": "0.30.5",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/modules/messages/index.ts
+++ b/src/modules/messages/index.ts
@@ -64,7 +64,7 @@ export class Messages {
 
       this.axiosClient.interceptors.request.use(
         this.options.authAxiosMiddleware,
-        function(error: any) {
+        function (error: any) {
           return Promise.reject(error);
         }
       );
@@ -106,8 +106,16 @@ export class Messages {
     formData.append('map', JSON.stringify({ '0': ['variables.input.files'] }));
     formData.append('0', file, file.name);
 
-    const response = await this.axiosClient.post('', formData);
+    // Get authorization headers before making the request
+    // This ensures the user auth token is included, not just admin keys
+    const authHeaders = await this.options.authAxiosMiddleware();
 
+    const response = await this.axiosClient.post('', formData, {
+      headers: {
+        ...authHeaders, // Include the authorization headers explicitly
+      }
+    });
+    
     return response;
   }
 


### PR DESCRIPTION
The problem is in the createMessageWithFile method, which isn't properly including the user authentication when sending the file upload request.
Looking at your code, I can see that:

The axiosClient is being created with the app key and admin key in the headers
There's an interceptor using this.options.authAxiosMiddleware, but this isn't being properly applied when making the FormData POST request
Unlike other methods that use the GraphQL client (which has all middleware properly configured), the direct axios POST doesn't include the user authorization token

The solution is to explicitly get the authorization headers from the middleware and include them in the request. Here's what's happening and how to fix it:

The authAxiosMiddleware function in KanvasCore returns an object with the Authorization header
However, when making the FormData request, you're not including these headers in the POST request
You need to explicitly call the middleware to get the auth headers and add them to your request