### PR TITLE
Add saveUserAppPreferences mutation and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.9",
+  "version": "0.30.10",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.10",
+  "version": "0.31.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -28,6 +28,7 @@ import {
   UPDATE_EMAIL_MUTATION,
   LINK_DEVICE_MUTATION,
   UNLINK_DEVICE_MUTATION,
+  SAVE_USER_APP_PREFERENCES_MUTATION,
 } from '../../mutations';
 import {
   UserInterface,
@@ -354,5 +355,13 @@ export class Users {
       variables: { data: input },
     });
     return response.data.unLinkDevice;
+  }
+
+  public async saveUserAppPreferences(preferences: object): Promise<boolean> {
+    const response = await this.client.mutate({
+      mutation: SAVE_USER_APP_PREFERENCES_MUTATION,
+      variables: { preferences: preferences },
+    });
+    return response.data.saveUserAppPreferences;
   }
 }

--- a/src/mutations/users.mutation.ts
+++ b/src/mutations/users.mutation.ts
@@ -226,3 +226,9 @@ export const UNLINK_DEVICE_MUTATION = gql`
     unLinkDevice(data: $data)
   }
 `;
+
+export const SAVE_USER_APP_PREFERENCES_MUTATION = gql`
+  mutation saveUserAppPreferences($preferences: Mixed!) {
+    saveUserAppPreferences(preferences: $preferences)
+  }
+`;

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -170,4 +170,16 @@ describe('Test the KanvasCore client', () => {
 
     expect(unlinkedDevice).toBeTruthy();
   });
+
+  it('test save user app preferences', async () => {
+    const client = getClient();
+    const preferences = {
+      preference_1: 1,
+      preference_2: 0,
+      preference_3: 1
+    };
+    const saveUserAppPreferences = await client.users.saveUserAppPreferences(preferences);
+    
+    expect(saveUserAppPreferences).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Introduce a mutation for saving user application preferences along with a corresponding test to ensure functionality. Update the version number to reflect the changes.